### PR TITLE
Run tests on pull requests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,10 +1,6 @@
 name: Run Tests
 
-on:
-  workflow_dispatch: null
-  push:
-    branches:
-      - main
+on: [ push, pull_request, workflow_dispatch ]
 
 jobs:
   run-tests:


### PR DESCRIPTION
Tests can be run on pull requests because they do not contain any secrets and do not interact with the Linode API.