### PR TITLE
CodeQL: Ignore bin files implicitly bundled by AOB

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "main" ]
   schedule:
-    - cron: '0 13 * * 5'
+    - cron: "0 13 * * 5"
 
 jobs:
   analyze:
@@ -32,6 +32,10 @@ jobs:
         build-mode: ${{ matrix.build-mode }}
         queries: security-and-quality
 
+        # Exclude packages bundled by Splunk AOB
+        config: |
+          paths-ignore:
+            - TA-linode/bin/ta_linode/aob_py3
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## 📝 Description

This pull request marks the directory that stores Python packages bundled implicitly by Splunk AOB (`TA-linode/bin/ta_linode/aob_py3`) as excluded from CodeQL scanning. This is necessary because the dependencies are managed by Splunk and Splunkbase has its own code scanning functionality. 
Sample workflow run: https://github.com/lgarber-akamai/splunk-addon-linode/actions/runs/12916691738/job/36021411253

## ✔️ How to Test

N/A
