### PR TITLE
TPT-3778: Add explicit GitHub Actions permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Continues Integration
 
 on: [ push, pull_request, workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📝 Description

Add explicit least-privilege `contents: read` permission to the combined test and lint workflow.

This addresses code scanning alert 71 for `actions/missing-workflow-permissions`. Code scanning alert 70 points to the historical `.github/workflows/lint.yaml`, which has already been removed from `main`; a subsequent default-branch scan should close that stale finding.